### PR TITLE
Make messagebox a live region

### DIFF
--- a/leaflet-messagebox.js
+++ b/leaflet-messagebox.js
@@ -14,6 +14,9 @@ L.Control.Messagebox = L.Control.extend({
         var elem = this._container;
         elem.innerHTML = message;
         elem.style.display = 'block';
+        elem.setAttribute('role', 'status');
+        elem.setAttribute('aria-live', 'polite');
+        elem.setAttribute('aria-atomic', 'true');
 
         timeout = timeout || this.options.timeout;
 


### PR DESCRIPTION
Making the messagebox a [_live region_](https://www.w3.org/TR/wai-aria/#dfn-live-region) is important as it conveys to screen readers that the content should be announced when added to the DOM, or otherwise has been updated. This PR adds the [`status` role](https://www.w3.org/TR/wai-aria/#status) (a live region role) to the messagebox.

The `role="status"` ARIA attribute is implicitly [`aria-live="polite"`](https://www.w3.org/TR/wai-aria/#aria-live) and [`aria-atomic="true"`](https://www.w3.org/TR/wai-aria/#aria-atomic), however it's best to be explicit with these values per [MDN advice](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#Preferring_specialized_live_region_roles):

> To maximize compatibility, add a redundant `aria-live="polite"` when using this role.

And looking at the [support table for `role=status`](https://a11ysupport.io/tech/aria/status_role#expectations), we can see that not all browsers convey the implicit `aria-atomic` value of `true` by announcing the entire region, so we're explicit about that too.

FWIW I've only tested this using 1 screen reader (ChromeVox), and it works as expected; the content is announced as it is visually displayed to the user.